### PR TITLE
Add player-team wrapper methods to UnifiedDataClient

### DIFF
--- a/mlb_data_lab/apis/unified_data_client.py
+++ b/mlb_data_lab/apis/unified_data_client.py
@@ -167,7 +167,13 @@ class UnifiedDataClient:
     
     def fetch_player_team_stats(self, player_id: int, year: int):
         return MlbStatsClient.fetch_player_team_stats(player_id, year)
-    
+
+    def get_player_teams_for_season(self, player_id: int, year: int, group: str = None, ids_only: bool = False):
+        return MlbStatsClient.get_player_teams_for_season(player_id, year, group=group, ids_only=ids_only)
+
+    def fetch_player_team(self, player_id: int, year: int):
+        return MlbStatsClient.fetch_player_team(player_id, year)
+
     def get_player_mlbam_id(self, player_id: int):
         return MlbStatsClient.get_player_mlbam_id(player_id)
     


### PR DESCRIPTION
## Summary
- expose player team queries via UnifiedDataClient wrappers
- add `get_player_teams_for_season` wrapper
- add `fetch_player_team` wrapper

## Testing
- `pytest` *(interrupted: 91 passed, then KeyboardInterrupt)*
- `pytest tests/stats/test_stats_display.py::test_plot_splits_stats`
- `pytest tests/utils/test_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689f9a5658a083268871195fdd27a584