### PR TITLE
refactor: remove statsapi usage in fetch_player_team

### DIFF
--- a/mlb_data_lab/apis/mlb_stats_client.py
+++ b/mlb_data_lab/apis/mlb_stats_client.py
@@ -321,17 +321,20 @@ class MlbStatsClient:
     #   https://statsapi.mlb.com/api/v1/people?personIds=111509&season=1984&hydrate=stats(group=[],type=season,team,season=1984)
     @staticmethod
     def fetch_player_team(player_id: int, year: int):
-        info = statsapi.get('people', {'personIds': player_id, 
-                                            'season': year, 
-                                            'hydrate': f'stats(group=[],type=season,team,season={year})'
-                                })['people'][0]['stats'][0]['splits']
+        url = (
+            f"{STATS_API_BASE_URL}people?"
+            f"personIds={player_id}"
+            f"&season={year}"
+            f"&hydrate=stats(group=[],type=season,team,season={year})"
+        )
+        data = MlbStatsClient._get_json(url)
+        splits = data["people"][0]["stats"][0]["splits"]
 
-        # Iterate over the elements in info to find the 'team' field
-        for element in info:
-            if 'team' in element:
-                return element['team']
-        
-        # Return None or handle case if no 'team' is found in any element
+        for element in splits:
+            team = element.get("team")
+            if team:
+                return team
+
         print(f"No team information found for player {player_id} in season {year}.")
         return None
 

--- a/tests/apis/test_mlb_stats_client.py
+++ b/tests/apis/test_mlb_stats_client.py
@@ -99,17 +99,20 @@ def test_fetch_player_team(monkeypatch):
         "people": [
             {
                 "stats": [
-                    {"splits": [{"team": {"teamName": "Test Team"}}]}
+                    {"splits": [{"team": {"id": 999, "teamName": "Test Team"}}]}
                 ]
             }
         ]
     }
-    def fake_statsapi_get(endpoint, params):
-        return fake_data
-    monkeypatch.setattr(statsapi, "get", fake_statsapi_get)
-    
+
+    def fake_get(url):
+        return FakeResponse(fake_data)
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
     result = MlbStatsClient.fetch_player_team(12345, 2020)
     assert result["teamName"] == "Test Team"
+    assert result["id"] == 999
 
 # ---------------------------
 # Test fetch_active_roster


### PR DESCRIPTION
## Summary
- fetch player team info directly from the MLB Stats API instead of relying on `statsapi`
- adjust unit tests for new implementation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f9e69c0b08326963c78453b6bd40c