### PR TITLE
test: add integration test for season stats download

### DIFF
--- a/tests/stats/test_save_season_stats_integration.py
+++ b/tests/stats/test_save_season_stats_integration.py
@@ -11,3 +11,20 @@ def test_fetch_player_stats_integration(tmp_path):
     assert isinstance(df, pd.DataFrame)
     assert not df.empty
     assert (df["mlbam_id"] == 545361).all()
+
+
+@pytest.mark.integration
+def test_download_integration(tmp_path, monkeypatch):
+    downloader = SeasonStatsDownloader(season=2023, output_dir=str(tmp_path))
+
+    def fake_gather_rosters(self):
+        roster_df = pd.DataFrame([{"mlbam_id": 545361}])
+        return [(108, roster_df)]
+
+    monkeypatch.setattr(SeasonStatsDownloader, "_gather_rosters", fake_gather_rosters)
+    output_file = tmp_path / "stats.csv"
+    downloader.download(output_file=str(output_file))
+    assert output_file.exists()
+    df = pd.read_csv(output_file)
+    assert not df.empty
+    assert (df["mlbam_id"] == 545361).all()


### PR DESCRIPTION
## Summary
- add integration test for `SeasonStatsDownloader.download`

## Testing
- `pytest tests/stats/test_save_season_stats_integration.py -vv`


------
https://chatgpt.com/codex/tasks/task_e_689fa9a7bb2c8326858279d1f995c63a