### PR TITLE
Fix multi-team season stats download

### DIFF
--- a/tests/stats/test_save_season_stats.py
+++ b/tests/stats/test_save_season_stats.py
@@ -43,6 +43,9 @@ class DummyClient:
     def fetch_batting_stats(self, mlbam_id, season, fangraphs_team_id=None):
         return self.bat_df
 
+    def get_player_teams_for_season(self, player_id, year, group=None, ids_only=False):
+        return [109]
+
 
 class DummyPlayerInfo:
     def __init__(self, pos):
@@ -64,7 +67,7 @@ def test_fetch_player_stats_success(monkeypatch, tmp_path):
     downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path))
     downloader.client = client
     monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
-    df = downloader._fetch_player_stats(1, 109)
+    df = downloader._fetch_player_stats(1)
     assert isinstance(df, pd.DataFrame)
     assert df["mlbam_id"].iloc[0] == 1
     assert df["season"].iloc[0] == 2024
@@ -76,6 +79,6 @@ def test_fetch_player_stats_position_mismatch(monkeypatch, tmp_path):
     downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path), player_type="batters")
     downloader.client = client
     monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
-    result = downloader._fetch_player_stats(2, 109)
+    result = downloader._fetch_player_stats(2)
     assert result is None
     assert downloader.statuses["position_mismatch"] == ["Dummy Player"]

--- a/tests/stats/test_save_season_stats.py
+++ b/tests/stats/test_save_season_stats.py
@@ -37,10 +37,10 @@ class DummyClient:
         self.pitch_df = pd.DataFrame({"wins": [1]})
         self.bat_df = pd.DataFrame({"hits": [5]})
 
-    def fetch_pitching_stats(self, mlbam_id, season):
+    def fetch_pitching_stats(self, mlbam_id, season, fangraphs_team_id=None):
         return self.pitch_df
 
-    def fetch_batting_stats(self, mlbam_id, season):
+    def fetch_batting_stats(self, mlbam_id, season, fangraphs_team_id=None):
         return self.bat_df
 
 
@@ -64,7 +64,7 @@ def test_fetch_player_stats_success(monkeypatch, tmp_path):
     downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path))
     downloader.client = client
     monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
-    df = downloader._fetch_player_stats(1)
+    df = downloader._fetch_player_stats(1, 109)
     assert isinstance(df, pd.DataFrame)
     assert df["mlbam_id"].iloc[0] == 1
     assert df["season"].iloc[0] == 2024
@@ -76,6 +76,6 @@ def test_fetch_player_stats_position_mismatch(monkeypatch, tmp_path):
     downloader = SeasonStatsDownloader(season=2024, output_dir=str(tmp_path), player_type="batters")
     downloader.client = client
     monkeypatch.setattr(save_season_stats.Player, "create_from_mlb", lambda mlbam_id, data_client=None: DummyPlayer("P"))
-    result = downloader._fetch_player_stats(2)
+    result = downloader._fetch_player_stats(2, 109)
     assert result is None
     assert downloader.statuses["position_mismatch"] == ["Dummy Player"]

--- a/tests/stats/test_save_season_stats_integration.py
+++ b/tests/stats/test_save_season_stats_integration.py
@@ -6,7 +6,7 @@ from mlb_data_lab.stats.save_season_stats import SeasonStatsDownloader
 @pytest.mark.integration
 def test_fetch_player_stats_integration(tmp_path):
     downloader = SeasonStatsDownloader(season=2023, output_dir=str(tmp_path))
-    df = downloader._fetch_player_stats(545361)  # Mike Trout
+    df = downloader._fetch_player_stats(545361, 108)  # Mike Trout on LAA
     assert df is not None
     assert isinstance(df, pd.DataFrame)
     assert not df.empty

--- a/tests/stats/test_save_season_stats_integration.py
+++ b/tests/stats/test_save_season_stats_integration.py
@@ -6,7 +6,7 @@ from mlb_data_lab.stats.save_season_stats import SeasonStatsDownloader
 @pytest.mark.integration
 def test_fetch_player_stats_integration(tmp_path):
     downloader = SeasonStatsDownloader(season=2023, output_dir=str(tmp_path))
-    df = downloader._fetch_player_stats(545361, 108)  # Mike Trout on LAA
+    df = downloader._fetch_player_stats(545361)  # Mike Trout
     assert df is not None
     assert isinstance(df, pd.DataFrame)
     assert not df.empty


### PR DESCRIPTION
## Summary
- map MLBAM team IDs to Fangraphs IDs and fetch team-specific stats
- return a row for each team a player appears on with that team's stats
- update tests for new team-aware season stat fetching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb0affd008326b10e18c8f40ecf7b