### PR TITLE
Avoid pandas concat FutureWarning in season stats saver

### DIFF
--- a/mlb_data_lab/stats/save_season_stats.py
+++ b/mlb_data_lab/stats/save_season_stats.py
@@ -271,7 +271,9 @@ class SeasonStatsDownloader:
                         season=self.season,
                         fangraphs_team_id=fg_id,
                     )
-                    if stats is None or stats.empty:
+                    # Drop dataframes that have no meaningful values to avoid
+                    # FutureWarning from pandas concat about empty or all-NA inputs
+                    if stats is None or stats.empty or stats.isna().all().all():
                         continue
                     stats["mlbam_id"] = mlbam_id
                     stats["season"] = self.season


### PR DESCRIPTION
## Summary
- skip stats DataFrames that are empty or entirely NA to avoid pandas concat FutureWarning

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fca2617d48326a799f888237a8a28