### PR TITLE
Handle all-NA DataFrames before concatenation

### DIFF
--- a/mlb_data_lab/stats/save_season_stats.py
+++ b/mlb_data_lab/stats/save_season_stats.py
@@ -271,9 +271,10 @@ class SeasonStatsDownloader:
                         season=self.season,
                         fangraphs_team_id=fg_id,
                     )
-                    # Drop dataframes that have no meaningful values to avoid
-                    # FutureWarning from pandas concat about empty or all-NA inputs
-                    if stats is None or stats.empty or stats.isna().all().all():
+                    # Drop columns with no data and skip entirely empty or all-NA frames
+                    if stats is not None:
+                        stats = stats.dropna(axis=1, how="all")
+                    if stats is None or stats.empty:
                         continue
                     stats["mlbam_id"] = mlbam_id
                     stats["season"] = self.season


### PR DESCRIPTION
## Summary
- Drop columns containing only NaN values before processing stat DataFrames
- Skip empty DataFrames to prevent pandas concat warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689fccc01c148326b2f22e0e6cef4cbf