### PR TITLE
Handle multi-team players in league totals and averages

### DIFF
--- a/tests/stats/test_league_team_stats.py
+++ b/tests/stats/test_league_team_stats.py
@@ -37,3 +37,47 @@ def test_compute_team_totals_and_averages():
         index=[team],
     )
     pd.testing.assert_frame_equal(avgs, expected_avgs)
+
+
+def create_multi_team_stats_df():
+    """Return stats with a player appearing for two teams and a total row."""
+    return pd.DataFrame(
+        {
+            "Pos": ["C", "C", "C", "1B", "OF"],
+            "xMLBAMID": [1, 1, 1, 2, 3],
+            "TeamName": ["BOS", "CHC", "- - -", "LAD", "NYY"],
+            "AB": [100, 50, 150, 200, 150],
+            "H": [30, 15, 45, 60, 50],
+            "HR": [5, 3, 8, 10, 8],
+            "SO": [20, 10, 30, 40, 30],
+            "RBI": [20, 15, 35, 50, 40],
+        }
+    )
+
+
+def test_league_totals_and_averages_include_multi_team_players():
+    stats = create_multi_team_stats_df()
+
+    totals = compute_leage_totals(2024, stats)
+    expected_totals = pd.DataFrame(
+        [
+            [250, 80, 13, 50, 60],
+            [250, 75, 13, 50, 65],
+            [500, 155, 26, 100, 125],
+        ],
+        columns=["AB", "H", "HR", "SO", "RBI"],
+        index=["AL", "NL", "MLB"],
+    )
+    pd.testing.assert_frame_equal(totals, expected_totals)
+
+    avgs = compute_league_averages(2024, stats)
+    expected_avgs = pd.DataFrame(
+        [
+            [2024, 125.0, 40.0, 6.5, 25.0, 30.0, 0.32],
+            [2024, 125.0, 37.5, 6.5, 25.0, 32.5, 0.3],
+            [2024, 125.0, 38.75, 6.5, 25.0, 31.25, 0.31],
+        ],
+        columns=["season", "AB", "H", "HR", "SO", "RBI", "BA"],
+        index=["AL", "NL", "MLB"],
+    )
+    pd.testing.assert_frame_equal(avgs, expected_avgs)


### PR DESCRIPTION
## Summary
- Aggregate player stats across teams before computing league totals to include multi-team players
- Compute league averages from per-player league totals to avoid double counting
- Add regression test covering players who played for multiple teams

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689fe2c416ec832682809c052e99229d